### PR TITLE
[wildcard] Prevent infinite loops for parameterized bounded params

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/parametrization/ResolvedTypeParameterValueProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/parametrization/ResolvedTypeParameterValueProvider.java
@@ -56,7 +56,11 @@ public interface ResolvedTypeParameterValueProvider {
         if (type.isWildcard() && type.asWildcard().isBounded()) {
             if (type.asWildcard().isExtends()) {
                 return ResolvedWildcard.extendsBound(useThisTypeParametersOnTheGivenType(type.asWildcard().getBoundedType()));
-            } else {
+            } else if (!(type instanceof ResolvedWildcard
+                && ((ResolvedWildcard) type).getBoundedType().equals(type.asWildcard().getBoundedType()))) {
+                // Condition prevents infinite loops upon encountering a parameter
+                // like this one:
+                // ConsumerRaisingIOE<T> andThen(ConsumerRaisingIOE<? super T> next) { }
                 return ResolvedWildcard.superBound(useThisTypeParametersOnTheGivenType(type.asWildcard().getBoundedType()));
             }
         }


### PR DESCRIPTION
This was previously triggered when the parser encountered code like this.
```
ConsumerRaisingIOE<T> andThen(ConsumerRaisingIOE<? super T> next) {
  // Some logic here
}
```